### PR TITLE
fix: static-analysis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Static analysis
         uses: dominikh/staticcheck-action@v1.2.0
         with:
-          version: "2022.1.1"
+          version: "2023.1.7"
           install-go: false
           cache-key: ${{ matrix.go }}
       - name: Test


### PR DESCRIPTION
Upgrades version to avoid panicking on go v1.22